### PR TITLE
Add music pages and navigation

### DIFF
--- a/pMusic/DI/ServiceCollection.cs
+++ b/pMusic/DI/ServiceCollection.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
+using pMusic.Interface;
 using pMusic.Services;
 using pMusic.ViewModels;
 using pMusic.Views;
@@ -13,5 +14,6 @@ public static class ServiceCollectionExtensions
         collection.AddHttpClient<Plex>();
         collection.AddTransient<MainViewModel>();
         collection.AddTransient<MainWindow>();
+        collection.AddSingleton<Navigation>();
     }
 }

--- a/pMusic/Interface/Navigation.cs
+++ b/pMusic/Interface/Navigation.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
 using pMusic.ViewModels;
 
@@ -23,12 +25,36 @@ public partial class Navigation : ObservableObject
     [ObservableProperty]
     private object? _currentView;
     
+    private readonly Dictionary<Type, ViewModelBase> _viewModels = new();
+    
     // Private constructor for singleton
     private Navigation()
     {
         CurrentView = _homeView;
     }
     
+    public void GoToView<T>(Action<T> intializer) where T : ViewModelBase, new()
+    {
+
+        var viewModel = GetViewModel<T>();
+        intializer(viewModel);
+        CurrentView = viewModel;
+    }
+    
+    // Factory method to get view model instances
+    public T GetViewModel<T>() where T : ViewModelBase, new()
+    {
+        Type type = typeof(T);
+        
+        // Create the view model if it doesn't exist yet
+        if (!_viewModels.ContainsKey(type))
+        {
+            _viewModels[type] = new T();
+        }
+        
+        return (T)_viewModels[type];
+    }
+
     public void GoToAlbum() => CurrentView = _albumView;
     public void GoToArtist() => CurrentView = _artistView;
     public void GoToTrack() => CurrentView = _trackView;

--- a/pMusic/Interface/Navigation.cs
+++ b/pMusic/Interface/Navigation.cs
@@ -1,0 +1,35 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using pMusic.ViewModels;
+
+namespace pMusic.Interface;
+
+public interface INavigation
+{
+    public void GoToAlbum();
+    public void GoToArtist();
+    public void GoToTrack();
+}
+
+public partial class Navigation : ObservableObject
+{
+    // Singleton instance
+    public static Navigation Instance { get; } = new();
+
+    private readonly HomeViewModel _homeView = new();
+    private readonly ArtistViewModel _artistView = new();
+    private readonly AlbumViewModel _albumView = new();
+    private readonly TrackViewModel _trackView = new();
+    
+    [ObservableProperty]
+    private object? _currentView;
+    
+    // Private constructor for singleton
+    private Navigation()
+    {
+        CurrentView = _homeView;
+    }
+    
+    public void GoToAlbum() => CurrentView = _albumView;
+    public void GoToArtist() => CurrentView = _artistView;
+    public void GoToTrack() => CurrentView = _trackView;
+}

--- a/pMusic/ViewModels/AlbumViewModel.cs
+++ b/pMusic/ViewModels/AlbumViewModel.cs
@@ -2,13 +2,16 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace pMusic.ViewModels;
 
-public partial class AlbumViewModel: ViewModelBase
+public partial class AlbumViewModel : ViewModelBase
 {
-    [ObservableProperty]
-    public string _title = "Album";
+    [ObservableProperty] public string _title = "Album";
+    [ObservableProperty] public string _albumTitle = "MUSIC";
+    [ObservableProperty] public string _albumArtist = "Playboi Carti";
+    [ObservableProperty] public string _albumReleaseDate = "2025";
+    [ObservableProperty] public string _albumTrackLength = "30";
+    [ObservableProperty] public string _albumDuration = "1h 16m";
 
     public AlbumViewModel()
     {
-        
     }
 }

--- a/pMusic/ViewModels/AlbumViewModel.cs
+++ b/pMusic/ViewModels/AlbumViewModel.cs
@@ -1,6 +1,14 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace pMusic.ViewModels;
 
-public class AlbumViewModel: ViewModelBase
+public partial class AlbumViewModel: ViewModelBase
 {
-    public string Title { get; } = "Album";
+    [ObservableProperty]
+    public string _title = "Album";
+
+    public AlbumViewModel()
+    {
+        
+    }
 }

--- a/pMusic/ViewModels/AlbumViewModel.cs
+++ b/pMusic/ViewModels/AlbumViewModel.cs
@@ -1,0 +1,6 @@
+namespace pMusic.ViewModels;
+
+public class AlbumViewModel: ViewModelBase
+{
+    public string Title { get; } = "Album";
+}

--- a/pMusic/ViewModels/ArtistViewModel.cs
+++ b/pMusic/ViewModels/ArtistViewModel.cs
@@ -1,6 +1,9 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace pMusic.ViewModels;
 
-public class ArtistViewModel: ViewModelBase
+public partial class ArtistViewModel: ViewModelBase
 {
-    public string Title { get; } = "Artist";
+    [ObservableProperty]
+    public string _title = "Title";
 }

--- a/pMusic/ViewModels/ArtistViewModel.cs
+++ b/pMusic/ViewModels/ArtistViewModel.cs
@@ -1,0 +1,6 @@
+namespace pMusic.ViewModels;
+
+public class ArtistViewModel: ViewModelBase
+{
+    public string Title { get; } = "Artist";
+}

--- a/pMusic/ViewModels/HomeViewModel.cs
+++ b/pMusic/ViewModels/HomeViewModel.cs
@@ -1,0 +1,6 @@
+namespace pMusic.ViewModels;
+
+public class HomeViewModel: ViewModelBase
+{
+    
+}

--- a/pMusic/ViewModels/MainViewModel.cs
+++ b/pMusic/ViewModels/MainViewModel.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+using System.Windows.Input;
 using System.Xml.Linq;
 using Avalonia;
 using Avalonia.Controls;
@@ -11,7 +12,9 @@ using Avalonia.Interactivity;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using KeySharp;
+using pMusic.Interface;
 using pMusic.Services;
 
 namespace pMusic.ViewModels;
@@ -24,6 +27,14 @@ public partial class MainViewModel : ViewModelBase
     [ObservableProperty] private bool _isLoggedIn = !string.IsNullOrEmpty(Keyring.GetPassword("com.ib.pmusic-avalonia", "pMusic-Avalonia", "authToken"));
     [ObservableProperty] private bool _isLoggedInTrue = string.IsNullOrEmpty(Keyring.GetPassword("com.ib.pmusic-avalonia", "pMusic-Avalonia", "authToken"));
     [ObservableProperty] private Bitmap _thumbnailUrl;
+
+    [ObservableProperty] private bool _isLoading;
+    
+    [ObservableProperty] private ViewModelBase _currentPage;
+    private readonly HomeViewModel _homeView = new();
+    private readonly ArtistViewModel _artistView = new ();
+    private readonly AlbumViewModel _albumView = new ();
+    private readonly TrackViewModel _trackView = new ();
 
     public MainViewModel(Plex plex)
     {

--- a/pMusic/ViewModels/TrackViewModel.cs
+++ b/pMusic/ViewModels/TrackViewModel.cs
@@ -1,6 +1,9 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace pMusic.ViewModels;
 
-public class TrackViewModel: ViewModelBase
+public partial class TrackViewModel: ViewModelBase
 {
-    public string Title { get; } = "Track";
+    [ObservableProperty]
+    public string _title = "Track Title";
 }

--- a/pMusic/ViewModels/TrackViewModel.cs
+++ b/pMusic/ViewModels/TrackViewModel.cs
@@ -1,0 +1,6 @@
+namespace pMusic.ViewModels;
+
+public class TrackViewModel: ViewModelBase
+{
+    public string Title { get; } = "Track";
+}

--- a/pMusic/ViewModels/ViewModelBase.cs
+++ b/pMusic/ViewModels/ViewModelBase.cs
@@ -10,16 +10,17 @@ public abstract partial class ViewModelBase : ObservableObject
     
     // Access to navigation
     protected Navigation Navigation => Navigation.Instance;    
+    
     // [RelayCommand]
     // public void GoToHome() => Navigation.GoToHome();
     
     [RelayCommand]
-    public void GoToAlbum() => Navigation.GoToAlbum();
+    public void GoToAlbum() => Navigation.GoToView<AlbumViewModel>(vm => vm.Title = "Hello");
     
     [RelayCommand]
-    public void GoToArtist() => Navigation.GoToArtist();
+    public void GoToArtist() => Navigation.GoToView<AlbumViewModel>(vm => vm.Title = "Updated Artist Title");
     
     [RelayCommand]
-    public void GoToTrack() => Navigation.GoToTrack();
+    public void GoToTrack() => Navigation.GoToView<TrackViewModel>(vm => vm.Title = "Updated Track Title");
     
 }

--- a/pMusic/ViewModels/ViewModelBase.cs
+++ b/pMusic/ViewModels/ViewModelBase.cs
@@ -18,8 +18,7 @@ public abstract partial class ViewModelBase : ObservableObject
     public void GoToAlbum() => Navigation.GoToView<AlbumViewModel>(vm => vm.Title = "Hello");
     
     [RelayCommand]
-    public void GoToArtist() => Navigation.GoToView<AlbumViewModel>(vm => vm.Title = "Updated Artist Title");
-    
+    public void GoToArtist() => Navigation.GoToView<ArtistViewModel>(vm => vm.Title = "Updated Artist Title");
     [RelayCommand]
     public void GoToTrack() => Navigation.GoToView<TrackViewModel>(vm => vm.Title = "Updated Track Title");
     

--- a/pMusic/ViewModels/ViewModelBase.cs
+++ b/pMusic/ViewModels/ViewModelBase.cs
@@ -1,7 +1,25 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using pMusic.Interface;
 
 namespace pMusic.ViewModels;
 
-public abstract class ViewModelBase : ObservableObject
+public abstract partial class ViewModelBase : ObservableObject
 {
+    
+    // Access to navigation
+    protected Navigation Navigation => Navigation.Instance;    
+    // [RelayCommand]
+    // public void GoToHome() => Navigation.GoToHome();
+    
+    [RelayCommand]
+    public void GoToAlbum() => Navigation.GoToAlbum();
+    
+    [RelayCommand]
+    public void GoToArtist() => Navigation.GoToArtist();
+    
+    [RelayCommand]
+    public void GoToTrack() => Navigation.GoToTrack();
+    
 }

--- a/pMusic/Views/AlbumView.axaml
+++ b/pMusic/Views/AlbumView.axaml
@@ -12,7 +12,7 @@
         <vm:AlbumViewModel />
     </Design.DataContext>
     <StackPanel>
-   <TextBlock>Welcome to Avalonia Album Page!</TextBlock>
+        <TextBlock Text="{Binding Title}"></TextBlock>
     <Button Content="Go To Artist Page" HorizontalAlignment="Stretch" Command="{Binding GoToArtist}" Height="50"></Button>
     </StackPanel>
 </UserControl>

--- a/pMusic/Views/AlbumView.axaml
+++ b/pMusic/Views/AlbumView.axaml
@@ -11,8 +11,114 @@
          to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
         <vm:AlbumViewModel />
     </Design.DataContext>
-    <StackPanel>
-        <TextBlock Text="{Binding Title}"></TextBlock>
-    <Button Content="Go To Artist Page" HorizontalAlignment="Stretch" Command="{Binding GoToArtist}" Height="50"></Button>
-    </StackPanel>
+    <ScrollViewer>
+        <Grid RowDefinitions="Auto, Auto, *">
+            <Grid ColumnDefinitions="Auto, *">
+                <Border CornerRadius="15" Margin="0 0 24 0" ClipToBounds="True">
+                    <Image Source="/Assets/Images/blank_playlist.png"></Image>
+                </Border>
+                <StackPanel Grid.Column="1">
+                    <TextBlock>Album</TextBlock>
+                    <TextBlock Text="{Binding AlbumTitle}"></TextBlock>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Border CornerRadius="1000" Margin="0 0 24 0" ClipToBounds="True">
+                            <Image Source="/Assets/Images/blank_playlist.png" Width="30" Height="30">
+                                <Image.Stretch></Image.Stretch>
+                            </Image>
+                        </Border>
+                        <TextBlock Text="{Binding AlbumArtist}"></TextBlock>
+                        <TextBlock Text="{Binding AlbumReleaseDate}"></TextBlock>
+                        <TextBlock Text="{Binding AlbumTrackLength}"></TextBlock>
+                        <TextBlock Text="{Binding AlbumDuration}"></TextBlock>
+                    </StackPanel>
+                </StackPanel>
+            </Grid>
+            <Grid Grid.Row="1" ColumnDefinitions="*, Auto" Margin="0 32">
+                <StackPanel Orientation="Horizontal">
+                    <Button Content="{LucideIconContent Play}" Height="50" Width="50" CornerRadius="1000"></Button>
+                    <Button Content="{LucideIconContent Shuffle}" Height="50" Width="50" CornerRadius="1000"></Button>
+                    <Button Content="{LucideIconContent CirclePlus}" Height="50" Width="50" CornerRadius="1000"></Button>
+                    <Button Content="{LucideIconContent Download}" Height="50" Width="50" CornerRadius="1000"></Button>
+                </StackPanel>
+                <TextBlock Grid.Column="1">
+                    List
+                    <Button Content="{LucideIconContent List}"></Button>
+                </TextBlock>
+            </Grid>
+            <StackPanel Grid.Row="2" HorizontalAlignment="Stretch" Spacing="16">
+                <StackPanel Orientation="Horizontal" Spacing="16">
+                    <TextBlock>1</TextBlock>
+                    <StackPanel>
+                        <TextBlock>POP OUT</TextBlock>
+                        <TextBlock>Playboi Carti</TextBlock>
+                    </StackPanel>
+                    <TextBlock>3,000,000</TextBlock>
+                    <Button Content="{LucideIconContent Plus}" Width="30" Height="30" Padding="0"
+                            HorizontalAlignment="Center" VerticalAlignment="Center" CornerRadius="1000">
+                    </Button>
+                    <TextBlock>2:41</TextBlock>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="16">
+                    <TextBlock>1</TextBlock>
+                    <StackPanel>
+                        <TextBlock>POP OUT</TextBlock>
+                        <TextBlock>Playboi Carti</TextBlock>
+                    </StackPanel>
+                    <TextBlock>3,000,000</TextBlock>
+                    <Button Content="{LucideIconContent Plus}" Width="30" Height="30" Padding="0"
+                            HorizontalAlignment="Center" VerticalAlignment="Center" CornerRadius="1000">
+                    </Button>
+                    <TextBlock>2:41</TextBlock>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="16">
+                    <TextBlock>1</TextBlock>
+                    <StackPanel>
+                        <TextBlock>POP OUT</TextBlock>
+                        <TextBlock>Playboi Carti</TextBlock>
+                    </StackPanel>
+                    <TextBlock>3,000,000</TextBlock>
+                    <Button Content="{LucideIconContent Plus}" Width="30" Height="30" Padding="0"
+                            HorizontalAlignment="Center" VerticalAlignment="Center" CornerRadius="1000">
+                    </Button>
+                    <TextBlock>2:41</TextBlock>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="16">
+                    <TextBlock>1</TextBlock>
+                    <StackPanel>
+                        <TextBlock>POP OUT</TextBlock>
+                        <TextBlock>Playboi Carti</TextBlock>
+                    </StackPanel>
+                    <TextBlock>3,000,000</TextBlock>
+                    <Button Content="{LucideIconContent Plus}" Width="30" Height="30" Padding="0"
+                            HorizontalAlignment="Center" VerticalAlignment="Center" CornerRadius="1000">
+                    </Button>
+                    <TextBlock>2:41</TextBlock>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="16">
+                    <TextBlock>1</TextBlock>
+                    <StackPanel>
+                        <TextBlock>POP OUT</TextBlock>
+                        <TextBlock>Playboi Carti</TextBlock>
+                    </StackPanel>
+                    <TextBlock>3,000,000</TextBlock>
+                    <Button Content="{LucideIconContent Plus}" Width="30" Height="30" Padding="0"
+                            HorizontalAlignment="Center" VerticalAlignment="Center" CornerRadius="1000">
+                    </Button>
+                    <TextBlock>2:41</TextBlock>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="16">
+                    <TextBlock>1</TextBlock>
+                    <StackPanel>
+                        <TextBlock>POP OUT</TextBlock>
+                        <TextBlock>Playboi Carti</TextBlock>
+                    </StackPanel>
+                    <TextBlock>3,000,000</TextBlock>
+                    <Button Content="{LucideIconContent Plus}" Width="30" Height="30" Padding="0"
+                            HorizontalAlignment="Center" VerticalAlignment="Center" CornerRadius="1000">
+                    </Button>
+                    <TextBlock>2:41</TextBlock>
+                </StackPanel>
+            </StackPanel>
+        </Grid>
+    </ScrollViewer>
 </UserControl>

--- a/pMusic/Views/AlbumView.axaml
+++ b/pMusic/Views/AlbumView.axaml
@@ -1,0 +1,18 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             xmlns:vm="clr-namespace:pMusic.ViewModels"
+             x:Class="pMusic.Views.AlbumView"
+             x:DataType="vm:AlbumViewModel">
+    <Design.DataContext>
+        <!-- This only sets the DataContext for the previewer in an IDE,
+         to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
+        <vm:AlbumViewModel />
+    </Design.DataContext>
+    <StackPanel>
+   <TextBlock>Welcome to Avalonia Album Page!</TextBlock>
+    <Button Content="Go To Artist Page" HorizontalAlignment="Stretch" Command="{Binding GoToArtist}" Height="50"></Button>
+    </StackPanel>
+</UserControl>

--- a/pMusic/Views/AlbumView.axaml.cs
+++ b/pMusic/Views/AlbumView.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace pMusic.Views;
+
+public partial class AlbumView : UserControl
+{
+    public AlbumView()
+    {
+        InitializeComponent();
+    }
+}

--- a/pMusic/Views/ArtistView.axaml
+++ b/pMusic/Views/ArtistView.axaml
@@ -11,8 +11,95 @@
          to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
         <vm:AlbumViewModel />
     </Design.DataContext>
-    <StackPanel>
-        <TextBlock Text="{Binding Title}"></TextBlock>
-        <Button Content="Go To Track Page" HorizontalAlignment="Stretch" Command="{Binding GoToTrack}" Height="50"></Button>
-    </StackPanel>
+    <ScrollViewer>
+        <Grid RowDefinitions="Auto, Auto, *">
+            <!-- <TextBlock Text="{Binding Title}"></TextBlock> -->
+            <Grid ColumnDefinitions="Auto, *">
+                <Border ClipToBounds="True" CornerRadius="1000">
+                    <Image Source="/Assets/Images/blank_playlist.png" Width="200"></Image>
+                </Border>
+                <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="36 0 0 0 ">
+                    <TextBlock VerticalAlignment="Center" FontSize="50">Kanye West</TextBlock>
+                    <!-- <TextBlock>Monthly Listeners 68,000,000</TextBlock> -->
+                </StackPanel>
+            </Grid>
+            <Grid Grid.Row="1" ColumnDefinitions="*, Auto" Margin="0 32">
+                <StackPanel Orientation="Horizontal">
+                    <Button Content="{LucideIconContent Play}" Height="50" Width="50" CornerRadius="1000"></Button>
+                    <Button Content="{LucideIconContent Shuffle}" Height="50" Width="50" CornerRadius="1000"></Button>
+                    <Button Content="{LucideIconContent CirclePlus}" Height="50" Width="50" CornerRadius="1000"></Button>
+                    <Button Content="{LucideIconContent Download}" Height="50" Width="50" CornerRadius="1000"></Button>
+                </StackPanel>
+                <TextBlock Grid.Column="1">
+                    List
+                    <Button Content="{LucideIconContent List}"></Button>
+                </TextBlock>
+            </Grid>
+            <Grid Grid.Row="2" RowDefinitions="Auto, Auto">
+                <TextBlock> Discography</TextBlock>
+                <StackPanel Grid.Row="1">
+                <TextBlock >Albums</TextBlock>
+                <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Hidden">
+                    <StackPanel Orientation="Horizontal" Spacing="24">
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+                    </StackPanel>
+            </Grid>
+            <!-- <Button Content="Go To Track Page" HorizontalAlignment="Stretch" Command="{Binding GoToTrack}" Height="50"></Button> -->
+        </Grid>
+    </ScrollViewer>
 </UserControl>

--- a/pMusic/Views/ArtistView.axaml
+++ b/pMusic/Views/ArtistView.axaml
@@ -1,0 +1,18 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             xmlns:vm="clr-namespace:pMusic.ViewModels"
+             x:Class="pMusic.Views.ArtistView"
+             x:DataType="vm:AlbumViewModel">
+    <Design.DataContext>
+        <!-- This only sets the DataContext for the previewer in an IDE,
+         to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
+        <vm:AlbumViewModel />
+    </Design.DataContext>
+    <StackPanel>
+        <TextBlock> Welcome to Avalonia Artist Page!</TextBlock>
+        <Button Content="Go To Track Page" HorizontalAlignment="Stretch" Command="{Binding GoToTrack}" Height="50"></Button>
+    </StackPanel>
+</UserControl>

--- a/pMusic/Views/ArtistView.axaml
+++ b/pMusic/Views/ArtistView.axaml
@@ -12,7 +12,7 @@
         <vm:AlbumViewModel />
     </Design.DataContext>
     <StackPanel>
-        <TextBlock> Welcome to Avalonia Artist Page!</TextBlock>
+        <TextBlock Text="{Binding Title}"></TextBlock>
         <Button Content="Go To Track Page" HorizontalAlignment="Stretch" Command="{Binding GoToTrack}" Height="50"></Button>
     </StackPanel>
 </UserControl>

--- a/pMusic/Views/ArtistView.axaml.cs
+++ b/pMusic/Views/ArtistView.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace pMusic.Views;
+
+public partial class ArtistView : UserControl
+{
+    public ArtistView()
+    {
+        InitializeComponent();
+    }
+}

--- a/pMusic/Views/HomeView.axaml
+++ b/pMusic/Views/HomeView.axaml
@@ -1,0 +1,79 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             xmlns:vm="clr-namespace:pMusic.ViewModels"
+             x:Class="pMusic.Views.HomeView"
+             x:DataType="vm:HomeViewModel">
+    <Design.DataContext>
+        <!-- This only sets the DataContext for the previewer in an IDE,
+         to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
+        <vm:HomeViewModel />
+    </Design.DataContext>
+    <StackPanel Grid.Column="2">
+        <!-- Filters for library type (Music, Podcats, Audiobooks, etc) -->
+        <!-- Recently Played -->
+        <UniformGrid Columns="2" Rows="4" Width="300">
+            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                </StackPanel>
+            </Border>
+            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                </StackPanel>
+            </Border>
+            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                </StackPanel>
+            </Border>
+            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                </StackPanel>
+            </Border>
+            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                </StackPanel>
+            </Border>
+            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                </StackPanel>
+            </Border>
+            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                </StackPanel>
+            </Border>
+            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                </StackPanel>
+            </Border>
+        </UniformGrid>
+        <StackPanel Orientation="Horizontal" Margin="10 0">
+            <!-- New Releases / Recently Added? -->
+            <Button Content="Go To Album" HorizontalAlignment="Stretch" Command="{Binding GoToAlbum}" Height="50"></Button>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="10 0">
+            <!-- Uniquely Yours -->
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="10 0">
+            <!-- Recently Added -->
+        </StackPanel>
+    </StackPanel>
+
+</UserControl>

--- a/pMusic/Views/HomeView.axaml
+++ b/pMusic/Views/HomeView.axaml
@@ -11,69 +11,251 @@
          to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
         <vm:HomeViewModel />
     </Design.DataContext>
-    <StackPanel Grid.Column="2">
-        <!-- Filters for library type (Music, Podcats, Audiobooks, etc) -->
-        <!-- Recently Played -->
-        <UniformGrid Columns="2" Rows="4" Width="300">
-            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                </StackPanel>
-            </Border>
-            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                </StackPanel>
-            </Border>
-            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                </StackPanel>
-            </Border>
-            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                </StackPanel>
-            </Border>
-            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                </StackPanel>
-            </Border>
-            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                </StackPanel>
-            </Border>
-            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                </StackPanel>
-            </Border>
-            <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                    <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                </StackPanel>
-            </Border>
-        </UniformGrid>
-        <StackPanel Orientation="Horizontal" Margin="10 0">
-            <!-- New Releases / Recently Added? -->
-            <Button Content="Go To Album" HorizontalAlignment="Stretch" Command="{Binding GoToAlbum}" Height="50"></Button>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="10 0">
-            <!-- Uniquely Yours -->
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="10 0">
-            <!-- Recently Added -->
-        </StackPanel>
-    </StackPanel>
-
+    <ScrollViewer IsScrollChainingEnabled="True">
+        <Grid Grid.RowDefinitions="*, *, *, *">
+            <!-- Filters for library type (Music, Podcats, Audiobooks, etc) -->
+            <!-- Recently Played -->
+            <UniformGrid Grid.Row="0" Columns="2" Rows="4" Width="300" Margin="0 32">
+                <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                        <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                    </StackPanel>
+                </Border>
+                <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                        <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                    </StackPanel>
+                </Border>
+                <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                        <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                    </StackPanel>
+                </Border>
+                <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                        <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                    </StackPanel>
+                </Border>
+                <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                        <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                    </StackPanel>
+                </Border>
+                <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                        <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                    </StackPanel>
+                </Border>
+                <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                        <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                    </StackPanel>
+                </Border>
+                <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
+                        <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
+                    </StackPanel>
+                </Border>
+            </UniformGrid>
+            <StackPanel Grid.Row="1" Margin="0 0 0 60" Spacing="24">
+                <TextBlock>Recently Played</TextBlock>
+                <!-- New Releases / Recently Added? -->
+                <ScrollViewer HorizontalScrollBarVisibility="Hidden">
+                    <StackPanel Orientation="Horizontal" Spacing="24">
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+                <!-- <Button Content="Go To Album" HorizontalAlignment="Stretch" Command="{Binding GoToAlbum}" Height="50"></Button> -->
+            </StackPanel>
+            <StackPanel Grid.Row="2" Margin="0 0 0 60" Spacing="24">
+                <!-- Uniquely Yours -->
+                <TextBlock>Recently Added</TextBlock>
+                <!-- New Releases / Recently Added? -->
+                <ScrollViewer HorizontalScrollBarVisibility="Hidden">
+                    <StackPanel Orientation="Horizontal" Spacing="24">
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+                <!-- <Button Content="Go To Album" HorizontalAlignment="Stretch" Command="{Binding GoToAlbum}" Height="50"></Button> -->
+            </StackPanel>
+            <StackPanel Grid.Row="3" Margin="0 0 0 60" Spacing="24">
+                <!-- Recently Added -->
+                <TextBlock>Uniqely Yours</TextBlock>
+                <!-- New Releases / Recently Added? -->
+                <ScrollViewer HorizontalScrollBarVisibility="Hidden">
+                    <StackPanel Orientation="Horizontal" Spacing="24">
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <Border CornerRadius="10" ClipToBounds="True">
+                                <Image Source="/Assets/Images/blank_playlist.png" Width="100"></Image>
+                            </Border>
+                            <TextBlock>RapCavier</TextBlock>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+                <!-- <Button Content="Go To Album" HorizontalAlignment="Stretch" Command="{Binding GoToAlbum}" Height="50"></Button> -->
+            </StackPanel>
+        </Grid>
+    </ScrollViewer>
 </UserControl>

--- a/pMusic/Views/HomeView.axaml.cs
+++ b/pMusic/Views/HomeView.axaml.cs
@@ -12,29 +12,4 @@ public partial class HomeView : UserControl
     {
         InitializeComponent();
     }
-
-    private void ScrollViewer_PointerWheelChanged(object? sender, PointerWheelEventArgs e)
-    {
-        if (e.Delta.Y != 0)
-        {
-            // Ignore vertical scrolling
-            e.Handled = true;
-            return;
-        }
-
-        Console.WriteLine($"Delta: x->{e.Delta.X} y->{e.Delta.Y}");
-        // Check if the scroll event is vertical
-        if (e.Delta.X == 0 && e.Delta.Y != 0)
-        {
-            Console.WriteLine($"Delta y: {e.Delta.Y}");
-            // Ignore vertical scrolling by marking the event as handled
-            e.Handled = true;
-            return;
-        }
-
-        Console.WriteLine($"Delta y happening: {e.Delta.Y}");
-
-        // For horizontal scrolling, do not mark the event as handled
-        // This allows the default horizontal scrolling behavior to occur
-    }
 }

--- a/pMusic/Views/HomeView.axaml.cs
+++ b/pMusic/Views/HomeView.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace pMusic.Views;
+
+public partial class HomeView : UserControl
+{
+    public HomeView()
+    {
+        InitializeComponent();
+    }
+}

--- a/pMusic/Views/HomeView.axaml.cs
+++ b/pMusic/Views/HomeView.axaml.cs
@@ -1,5 +1,7 @@
+using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 
 namespace pMusic.Views;
@@ -9,5 +11,30 @@ public partial class HomeView : UserControl
     public HomeView()
     {
         InitializeComponent();
+    }
+
+    private void ScrollViewer_PointerWheelChanged(object? sender, PointerWheelEventArgs e)
+    {
+        if (e.Delta.Y != 0)
+        {
+            // Ignore vertical scrolling
+            e.Handled = true;
+            return;
+        }
+
+        Console.WriteLine($"Delta: x->{e.Delta.X} y->{e.Delta.Y}");
+        // Check if the scroll event is vertical
+        if (e.Delta.X == 0 && e.Delta.Y != 0)
+        {
+            Console.WriteLine($"Delta y: {e.Delta.Y}");
+            // Ignore vertical scrolling by marking the event as handled
+            e.Handled = true;
+            return;
+        }
+
+        Console.WriteLine($"Delta y happening: {e.Delta.Y}");
+
+        // For horizontal scrolling, do not mark the event as handled
+        // This allows the default horizontal scrolling behavior to occur
     }
 }

--- a/pMusic/Views/MainView.axaml
+++ b/pMusic/Views/MainView.axaml
@@ -3,6 +3,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:pMusic.ViewModels"
+             xmlns:local="clr-namespace:pMusic.Interface"
+             xmlns:views="clr-namespace:pMusic.Views"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="pMusic.Views.MainView"
              x:DataType="vm:MainViewModel">
@@ -120,69 +122,22 @@
             <Border Grid.Column="2" BorderBrush="Black" CornerRadius="4" Background="Gainsboro"
                     BorderThickness="2"
                     Padding="8" Margin="0 4 8 2">
-                <StackPanel Grid.Column="2">
-                    <!-- Filters for library type (Music, Podcats, Audiobooks, etc) -->
-                    <!-- Recently Played -->
-                    <UniformGrid Columns="2" Rows="4" Width="300">
-                        <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                            <StackPanel Orientation="Horizontal" Spacing="8">
-                                <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                                <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                            </StackPanel>
-                        </Border>
-                        <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                            <StackPanel Orientation="Horizontal" Spacing="8">
-                                <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                                <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                            </StackPanel>
-                        </Border>
-                        <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                            <StackPanel Orientation="Horizontal" Spacing="8">
-                                <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                                <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                            </StackPanel>
-                        </Border>
-                        <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                            <StackPanel Orientation="Horizontal" Spacing="8">
-                                <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                                <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                            </StackPanel>
-                        </Border>
-                        <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                            <StackPanel Orientation="Horizontal" Spacing="8">
-                                <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                                <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                            </StackPanel>
-                        </Border>
-                        <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                            <StackPanel Orientation="Horizontal" Spacing="8">
-                                <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                                <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                            </StackPanel>
-                        </Border>
-                        <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                            <StackPanel Orientation="Horizontal" Spacing="8">
-                                <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                                <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                            </StackPanel>
-                        </Border>
-                        <Border CornerRadius="5" ClipToBounds="True" Background="Azure" Width="130">
-                            <StackPanel Orientation="Horizontal" Spacing="8">
-                                <Image Source="/Assets/Images/blank_playlist.png" Width="30"></Image>
-                                <TextBlock VerticalAlignment="Center">Liked Songs</TextBlock>
-                            </StackPanel>
-                        </Border>
-                    </UniformGrid>
-                    <StackPanel Orientation="Horizontal" Margin="10 0">
-                        <!-- New Releases / Recently Added? -->
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal" Margin="10 0">
-                        <!-- Uniquely Yours -->
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal" Margin="10 0">
-                        <!-- Recently Added -->
-                    </StackPanel>
-                </StackPanel>
+                <UserControl Content="{Binding CurrentView, Source={x:Static local:Navigation.Instance}}">
+                    <ContentControl.DataTemplates>
+                        <DataTemplate DataType="{x:Type vm:HomeViewModel}">
+                            <views:HomeView />
+                        </DataTemplate>
+                        <DataTemplate DataType="{x:Type vm:AlbumViewModel}">
+                            <views:AlbumView />
+                        </DataTemplate>
+                        <DataTemplate DataType="{x:Type vm:ArtistViewModel}">
+                            <views:ArtistView />
+                        </DataTemplate>
+                        <DataTemplate DataType="{x:Type vm:TrackViewModel}">
+                            <views:TrackView />
+                        </DataTemplate>
+                    </ContentControl.DataTemplates>
+                </UserControl>
             </Border>
         </Grid>
         <Grid Grid.Row="2" Height="70">

--- a/pMusic/Views/TrackView.axaml
+++ b/pMusic/Views/TrackView.axaml
@@ -11,5 +11,5 @@
          to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
         <vm:TrackViewModel />
     </Design.DataContext>
-    Welcome to Avalonia Track Page!
+    <TextBlock Text="{Binding Title}"></TextBlock>
 </UserControl>

--- a/pMusic/Views/TrackView.axaml
+++ b/pMusic/Views/TrackView.axaml
@@ -1,0 +1,15 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             xmlns:vm="clr-namespace:pMusic.ViewModels"
+             x:Class="pMusic.Views.TrackView"
+             x:DataType="vm:TrackViewModel">
+    <Design.DataContext>
+        <!-- This only sets the DataContext for the previewer in an IDE,
+         to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
+        <vm:TrackViewModel />
+    </Design.DataContext>
+    Welcome to Avalonia Track Page!
+</UserControl>

--- a/pMusic/Views/TrackView.axaml.cs
+++ b/pMusic/Views/TrackView.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace pMusic.Views;
+
+public partial class TrackView : UserControl
+{
+    public TrackView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
Added the templates with no data populating for the Homepage, Album Page, and Artist Page. Navigation between these pages also supports the handling and populating of data.