### PR TITLE
Fixed progress bar length.

### DIFF
--- a/pMusic/Audio/Bass/Flac/BassFlacPlayer.cs
+++ b/pMusic/Audio/Bass/Flac/BassFlacPlayer.cs
@@ -53,7 +53,8 @@ public class BassFlacPlayer : IAudioPlayer
 
         // Set MusicPlayer information (Accessible in UI)
         _musicPlayer.Position = 0;
-        _musicPlayer.Duration = ManagedBass.Bass.ChannelGetLength(_stream);
+        _musicPlayer.Duration =
+            ManagedBass.Bass.ChannelBytes2Seconds(_stream, ManagedBass.Bass.ChannelGetLength(_stream));
         _musicPlayer.MPlaybackState = PlaybackState.Playing;
         _musicPlayer.IsPlaying = true;
         _musicPlayer.Track = track;

--- a/pMusic/Audio/MusicPlayer.cs
+++ b/pMusic/Audio/MusicPlayer.cs
@@ -19,7 +19,7 @@ public partial class MusicPlayer : ObservableObject
     [ObservableProperty] public Artist artist;
     [ObservableProperty] public IAudioBackend audioBackend;
     [ObservableProperty] public IAudioPlayer audioPlayer;
-    [ObservableProperty] public long duration;
+    [ObservableProperty] public double? duration = null;
     [ObservableProperty] ObservableQueue<Track> highPriorityTracks = new();
     [ObservableProperty] ObservableCollection<Track> highPriorityTracksBacking = new();
     [ObservableProperty] public Bitmap image;

--- a/pMusic/Audio/Services/Playback.cs
+++ b/pMusic/Audio/Services/Playback.cs
@@ -69,7 +69,7 @@ public class Playback
         if (bassState is ManagedBass.PlaybackState.Stopped)
         {
             await _timer.DisposeAsync();
-            if (playerPosition / _musicPlayer.Duration * 100 > 90)
+            if (playerPosition / (decimal)_musicPlayer.Duration * 100 > 90)
                 await TrackCompleted(_track.RatingKey);
 
             return;

--- a/pMusic/ViewModels/MainViewModel.cs
+++ b/pMusic/ViewModels/MainViewModel.cs
@@ -142,6 +142,7 @@ public partial class MainViewModel : ViewModelBase
 
     public void Seek(double value)
     {
+        if (!MusicPlayer.IsPlaying) return;
         MusicPlayer.AudioBackend.Seek(value);
     }
 

--- a/pMusic/Views/MainView.axaml
+++ b/pMusic/Views/MainView.axaml
@@ -178,7 +178,7 @@
                                VerticalAlignment="Center" Margin="8 4" />
                 </StackPanel>
             </StackPanel>
-            <StackPanel Grid.Column="1" VerticalAlignment="Stretch">
+            <StackPanel Grid.Column="1" VerticalAlignment="Stretch" HorizontalAlignment="Center">
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center"
                             Spacing="8">
                     <Button
@@ -214,20 +214,21 @@
                         <heroIcons:HeroIcon Foreground="{DynamicResource SukiText}" Type="Forward" />
                     </Button>
                 </StackPanel>
-                <Grid ColumnDefinitions="30, 250, *"
-                      VerticalAlignment="Center" HorizontalAlignment="Center">
+                <Grid ColumnDefinitions="30, *, 30" HorizontalAlignment="Stretch">
                     <TextBlock
                         Text="{Binding MusicPlayer.Position, Converter={StaticResource SecondsToMinutesConverter}}"
                         VerticalAlignment="Center" />
-                    <Slider Grid.Column="1" Maximum="{Binding MusicPlayer.Track.Duration}"
-                            Value="{Binding MusicPlayer.Position}" Width="250" Padding="4 0"
-                            Thumb.DragCompleted="Thumb_OnDragCompleted" x:Name="MySlider"
-                            VerticalAlignment="Center" AttachedToVisualTree="Slider_AttachedToVisualTree" />
-
+                    <Slider Grid.Column="1" Value="{Binding MusicPlayer.Position}"
+                            Maximum="{Binding MusicPlayer.Duration}"
+                            Width="350"
+                            Thumb.DragCompleted="Thumb_OnDragCompleted"
+                            x:Name="MySlider" VerticalAlignment="Center"
+                            AttachedToVisualTree="Slider_AttachedToVisualTree" />
                     <TextBlock Grid.Column="2"
                                Text="{Binding MusicPlayer.Track.Duration, Converter={StaticResource SecondsToMinutesConverter}}"
                                VerticalAlignment="Center" />
                 </Grid>
+
             </StackPanel>
             <StackPanel Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Orientation="Horizontal">
                 <Button Classes="Basic Icon" Command="{Binding ToggleSidecarCommand}" VerticalAlignment="Center">


### PR DESCRIPTION
The progress bath is now long enough to hold every track in length, wherein before it used to cut off if the track was too long.