### PR TITLE
Standard view layout.

### DIFF
--- a/pMusic/Views/MainView.axaml
+++ b/pMusic/Views/MainView.axaml
@@ -94,7 +94,7 @@
                 </Button>
             </StackPanel>
         </Grid>
-        <Grid Grid.Row="1" ColumnDefinitions="Auto, *, Auto, Auto">
+        <Grid Grid.Row="1" ColumnDefinitions="Auto, 2*, Auto">
             <!-- Sidebar -->
             <suki:SukiSideMenu IsSearchEnabled="True"
                                ItemsSource="{Binding Sidebar.Pinned}"
@@ -138,7 +138,7 @@
                 </suki:SukiSideMenu.HeaderContent>
             </suki:SukiSideMenu>
             <!-- Main Content -->
-            <suki:GlassCard Grid.Column="1" IsAnimated="False" CornerRadius="17" Margin="4 5 0 10" Padding="0">
+            <suki:GlassCard Grid.Column="1" CornerRadius="17" Margin="4 5 0 10" Padding="0">
                 <UserControl Content="{Binding CurrentView, Source={x:Static local:Navigation.Instance}}">
                     <ContentControl.DataTemplates>
                         <DataTemplate DataType="{x:Type vm:HomeViewModel}">
@@ -156,11 +156,8 @@
                     </ContentControl.DataTemplates>
                 </UserControl>
             </suki:GlassCard>
-            <GridSplitter ResizeDirection="Columns" Width="4" Foreground="Transparent" Background="Transparent"
-                          Grid.Column="2">
-            </GridSplitter>
-            <suki:GlassCard Grid.Column="3" IsAnimated="False" CornerRadius="17" Margin="0 5 10 10" Padding="0"
-                            IsVisible="{Binding IsSidecarOpen}" MaxWidth="250">
+            <suki:GlassCard Grid.Column="3" CornerRadius="17" Margin="4 5 10 10" Padding="0"
+                            IsVisible="{Binding IsSidecarOpen}" MinWidth="250">
                 <views:SidecarView />
             </suki:GlassCard>
         </Grid>


### PR DESCRIPTION
The three layer colon is now standard for all views, no matter the size of the screen. This follows with the removal of the great splitters where before the sidebar had a great split angle was removed. Now the queue section has had its great splitter removed and given a standard minimum width. As well, animations have been added back to the opening and closing of the key and the expanding of the main section.