### PR TITLE
Add artist library browsing with paginated Plex data

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ On install login to you Plex account and select your server[^1], that is all.
 - [x] Add Screenshots
 - [x] Artist page
   - [x] Play popular tracks
-  - [ ] Artist library page
+  - [x] Artist library page
 - [x] Playlist page
   - [ ] Play entire playlist
   - [ ] Play individual track for playlist

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -54,6 +54,8 @@ const rpc = BrowserView.defineRPC<RaynaRPC>({
       mediaGetPlaylists: () => media.getPlaylists(),
       mediaGetAlbumsPage: ({ cursor, pageSize }) =>
         media.getAlbumsPage(cursor, pageSize),
+      mediaGetArtistsPage: ({ cursor, pageSize }) =>
+        media.getArtistsPage(cursor, pageSize),
       mediaGetAlbum: ({ ratingKey }) => media.getAlbum(ratingKey),
       mediaGetArtist: ({ ratingKey }) => media.getArtist(ratingKey),
       mediaGetArtistAlbums: ({ ratingKey }) => media.getArtistAlbums(ratingKey),

--- a/src/bun/plex/media.ts
+++ b/src/bun/plex/media.ts
@@ -105,6 +105,59 @@ export class MediaService {
     };
   }
 
+  async getArtistsPage(cursor = "", pageSize = 30): Promise<unknown> {
+    const sections = await this.getSelectedMusicSections();
+    let { sectionIndex, offset } = this.decodeCursor(cursor);
+    const initialSectionIndex = sectionIndex;
+    const initialOffset = offset;
+    const artists: PlexMetadata[] = [];
+
+    while (artists.length < pageSize && sectionIndex < sections.length) {
+      const section = sections[sectionIndex];
+      const data = await this.fetchPlex(
+        `/library/sections/${section.key}/all`,
+        {
+          type: "8",
+          "X-Plex-Container-Start": String(offset),
+          "X-Plex-Container-Size": String(pageSize - artists.length),
+        },
+      );
+      const artistData =
+        data.MediaContainer?.Metadata || data.MediaContainer?.Directory || [];
+
+      if (artistData.length === 0) {
+        sectionIndex += 1;
+        offset = 0;
+        continue;
+      }
+
+      artists.push(...artistData);
+      offset += artistData.length;
+
+      const totalSize = data.MediaContainer?.totalSize || 0;
+      if (offset >= totalSize) {
+        sectionIndex += 1;
+        offset = 0;
+      }
+    }
+
+    return {
+      items: artists.map((artist) => this.mapArtist(artist)),
+      nextCursor:
+        sectionIndex < sections.length
+          ? this.encodeCursor(sectionIndex, offset)
+          : null,
+      prevCursor:
+        initialOffset > 0 || initialSectionIndex > 0
+          ? this.encodeCursor(
+              initialSectionIndex,
+              Math.max(0, initialOffset - pageSize),
+            )
+          : null,
+      hasMore: sectionIndex < sections.length,
+    };
+  }
+
   async getRecentlyPlayedAlbums(): Promise<unknown[]> {
     const albums = await this.getAlbumsFromSections({
       sort: "lastViewedAt:desc",
@@ -176,13 +229,13 @@ export class MediaService {
   }
 
   async getAlbum(ratingKey: string): Promise<unknown> {
-    const album = await this.fetchMetadataItem(ratingKey)
+    const album = await this.fetchMetadataItem(ratingKey);
     const [tracks, ultraBlur] = await Promise.all([
       this.fetchMetadataChildren(ratingKey),
       this.getUltraBlur(album.art || album.thumb, `album-${ratingKey}`),
-    ])
+    ]);
     const artistKey =
-      album.parentRatingKey || this.extractRatingKey(album.parentKey)
+      album.parentRatingKey || this.extractRatingKey(album.parentKey);
 
     return {
       id: album.key,
@@ -202,12 +255,15 @@ export class MediaService {
         duration: track.duration,
         ratingKey: track.ratingKey,
       })),
-    }
+    };
   }
 
-async getArtist(ratingKey: string): Promise<unknown> {
-    const artist = await this.fetchMetadataItem(ratingKey)
-    const ultraBlur = await this.getUltraBlur(artist.thumb, `artist-${ratingKey}`)
+  async getArtist(ratingKey: string): Promise<unknown> {
+    const artist = await this.fetchMetadataItem(ratingKey);
+    const ultraBlur = await this.getUltraBlur(
+      artist.thumb,
+      `artist-${ratingKey}`,
+    );
 
     return {
       id: artist.key,
@@ -218,29 +274,32 @@ async getArtist(ratingKey: string): Promise<unknown> {
       art: this.plexUrl(artist.art),
       ultraBlur,
       viewCount: artist.viewCount,
-    }
+    };
   }
 
-  async getUltraBlur(imagePath: string | null, cacheBuster?: string): Promise<string | null> {
-    if (!imagePath) return null
+  async getUltraBlur(
+    imagePath: string | null,
+    cacheBuster?: string,
+  ): Promise<string | null> {
+    if (!imagePath) return null;
 
     try {
-      const colors = await this.fetchPlex('/services/ultrablur/colors', {
+      const colors = await this.fetchPlex("/services/ultrablur/colors", {
         url: imagePath,
-      })
-      const blurColors = colors.MediaContainer?.UltraBlurColors?.[0]
-      if (!blurColors) return null
+      });
+      const blurColors = colors.MediaContainer?.UltraBlurColors?.[0];
+      if (!blurColors) return null;
 
-      const ultraBlurImagePath = `/services/ultrablur/image?topLeft=${blurColors.topLeft}&topRight=${blurColors.topRight}&bottomLeft=${blurColors.bottomLeft}&bottomRight=${blurColors.bottomRight}&width=1920&height=1080&noise=1`
+      const ultraBlurImagePath = `/services/ultrablur/image?topLeft=${blurColors.topLeft}&topRight=${blurColors.topRight}&bottomLeft=${blurColors.bottomLeft}&bottomRight=${blurColors.bottomRight}&width=1920&height=1080&noise=1`;
 
-      return this.plexUrl('/photo/:/transcode', {
+      return this.plexUrl("/photo/:/transcode", {
         url: ultraBlurImagePath,
-        width: '1920',
-        height: '1080',
+        width: "1920",
+        height: "1080",
         ...(cacheBuster ? { v: cacheBuster } : {}),
-      })
+      });
     } catch {
-      return null
+      return null;
     }
   }
 
@@ -631,6 +690,21 @@ async getArtist(ratingKey: string): Promise<unknown> {
       addedAt: album.addedAt,
       lastViewedAt: album.lastViewedAt,
       thumb: this.plexUrl(album.thumb),
+    };
+  }
+
+  private mapArtist(artist: PlexMetadata): Record<string, unknown> {
+    return {
+      id: artist.key,
+      title: artist.title,
+      ratingKey: artist.ratingKey || this.extractRatingKey(artist.key),
+      addedAt: artist.addedAt,
+      lastViewedAt: artist.lastViewedAt,
+      thumb: this.plexUrl(artist.thumb),
+      art: this.plexUrl(artist.art),
+      albumCount: artist.childCount,
+      trackCount: artist.leafCount,
+      viewCount: artist.viewCount,
     };
   }
 

--- a/src/renderer/src/components/app-sidebar.tsx
+++ b/src/renderer/src/components/app-sidebar.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
 import * as React from "react";
 import {
   Sidebar,
@@ -13,6 +12,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import {
   AudioWave01FreeIcons,
   Home02Icon,
+  MusicNote03Icon,
   Vynil03Icon,
 } from "@hugeicons/core-free-icons";
 import { NavLibrary } from "./nav-library";
@@ -107,7 +107,7 @@ const data = {
     //   icon: Heart,
     // },
     { name: "Albums", url: "/app/library/albums", icon: Vynil03Icon },
-    // { name: "Artits", url: "/app/library/artists", icon: DiscAlbum },
+    { name: "Artists", url: "/app/library/artists", icon: MusicNote03Icon },
     // { name: "Playlists", url: "/app/library/playlists", icon: DiscAlbum },
     // {
     //   name: "All Music",

--- a/src/renderer/src/electrobun.ts
+++ b/src/renderer/src/electrobun.ts
@@ -1,22 +1,22 @@
-import { createRPC, Electroview } from 'electrobun/view'
-import type { PlaybackSettings, RaynaRPC } from '../../shared/rpc'
-import type { PlexServer } from '../../shared/types'
+import { createRPC, Electroview } from "electrobun/view";
+import type { PlaybackSettings, RaynaRPC } from "../../shared/rpc";
+import type { PlexServer } from "../../shared/types";
 
-const rpc = createRPC<RaynaRPC['webview'], RaynaRPC['bun']>({
-  maxRequestTime: 30_000
-})
+const rpc = createRPC<RaynaRPC["webview"], RaynaRPC["bun"]>({
+  maxRequestTime: 30_000,
+});
 
-new Electroview({ rpc })
+new Electroview({ rpc });
 
 window.api = {
   db: {
     get: (key: string) => rpc.request.dbGet({ key }),
-    set: (key: string, value: unknown) => rpc.request.dbSet({ key, value })
+    set: (key: string, value: unknown) => rpc.request.dbSet({ key, value }),
   },
   settings: {
     getPlayback: () => rpc.request.settingsGetPlayback(),
     setPlayback: (settings: PlaybackSettings) =>
-      rpc.request.settingsSetPlayback({ settings })
+      rpc.request.settingsSetPlayback({ settings }),
   },
   auth: {
     generateClientIdentifier: () => rpc.request.authGenerateClientIdentifier(),
@@ -37,10 +37,10 @@ window.api = {
     getUserAccessToken: () => rpc.request.authGetUserAccessToken(),
     getUserProfile: () => rpc.request.authGetUserProfile(),
     getUserSelectedLibraries: () => rpc.request.authGetUserSelectedLibraries(),
-    closeLoopbackServer: () => rpc.request.authCloseLoopbackServer()
+    closeLoopbackServer: () => rpc.request.authCloseLoopbackServer(),
   },
   bass: {
-    getStatus: () => rpc.request.bassGetStatus()
+    getStatus: () => rpc.request.bassGetStatus(),
   },
   media: {
     getHomeData: () => rpc.request.mediaGetHomeData(),
@@ -50,6 +50,8 @@ window.api = {
     getPlaylists: () => rpc.request.mediaGetPlaylists(),
     getAlbumsPage: (cursor: string, pageSize: number) =>
       rpc.request.mediaGetAlbumsPage({ cursor, pageSize }),
+    getArtistsPage: (cursor: string, pageSize: number) =>
+      rpc.request.mediaGetArtistsPage({ cursor, pageSize }),
     getAlbum: (ratingKey: string) => rpc.request.mediaGetAlbum({ ratingKey }),
     getArtist: (ratingKey: string) => rpc.request.mediaGetArtist({ ratingKey }),
     getArtistAlbums: (ratingKey: string) =>
@@ -57,7 +59,7 @@ window.api = {
     getArtistPopularTracks: (ratingKey: string) =>
       rpc.request.mediaGetArtistPopularTracks({ ratingKey }),
     getPlaylist: (ratingKey: string) =>
-      rpc.request.mediaGetPlaylist({ ratingKey })
+      rpc.request.mediaGetPlaylist({ ratingKey }),
   },
   player: {
     getStatus: () => rpc.request.playerGetStatus(),
@@ -75,6 +77,6 @@ window.api = {
     prev: () => rpc.request.playerPrev(),
     seek: (position: number) => rpc.request.playerSeek({ position }),
     setVolume: (volume: number) => rpc.request.playerSetVolume({ volume }),
-    setMuted: (muted: boolean) => rpc.request.playerSetMuted({ muted })
-  }
-}
+    setMuted: (muted: boolean) => rpc.request.playerSetMuted({ muted }),
+  },
+};

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -4,81 +4,82 @@ import type {
   BassStatus,
   PlaybackSettings,
   PlayerStatus,
-  UserProfile
-} from '../../shared/rpc'
-import type { PlexLibrary, PlexServer } from '../../shared/types'
+  UserProfile,
+} from "../../shared/rpc";
+import type { PlexLibrary, PlexServer } from "../../shared/types";
 
 declare global {
   interface Window {
     api: {
       db: {
-        get: (key: string) => Promise<unknown>
-        set: (key: string, value: unknown) => Promise<void>
-      }
+        get: (key: string) => Promise<unknown>;
+        set: (key: string, value: unknown) => Promise<void>;
+      };
       settings: {
-        getPlayback: () => Promise<PlaybackSettings>
-        setPlayback: (settings: PlaybackSettings) => Promise<PlaybackSettings>
-      }
+        getPlayback: () => Promise<PlaybackSettings>;
+        setPlayback: (settings: PlaybackSettings) => Promise<PlaybackSettings>;
+      };
       auth: {
-        isUserSignedIn: () => Promise<boolean>
-        logout: () => Promise<boolean>
-        generateClientIdentifier: () => Promise<string>
-        generateKeyPair: () => Promise<[string, string]>
-        generatePin: () => Promise<unknown>
+        isUserSignedIn: () => Promise<boolean>;
+        logout: () => Promise<boolean>;
+        generateClientIdentifier: () => Promise<string>;
+        generateKeyPair: () => Promise<[string, string]>;
+        generatePin: () => Promise<unknown>;
         checkPin: () => Promise<{
-          authUrl: string
-          plexId: string
-          plexCode: string
-        }>
-        checkPinStatus: (id: string) => Promise<any>
-        getServers: () => Promise<PlexServer[]>
-        getLibraries: () => Promise<PlexLibrary[]>
-        selectServer: (server: PlexServer) => Promise<void>
-        selectLibraries: (libraries: unknown[]) => Promise<void>
-        isServerSelected: () => Promise<boolean>
-        getUserSelectedServer: () => Promise<PlexServer | null>
-        getUserSelectedLibraries: () => Promise<unknown[] | null>
-        getUserAccessToken: () => Promise<string>
-        getUserProfile: () => Promise<UserProfile | null>
-        closeLoopbackServer: () => Promise<void>
-      }
+          authUrl: string;
+          plexId: string;
+          plexCode: string;
+        }>;
+        checkPinStatus: (id: string) => Promise<any>;
+        getServers: () => Promise<PlexServer[]>;
+        getLibraries: () => Promise<PlexLibrary[]>;
+        selectServer: (server: PlexServer) => Promise<void>;
+        selectLibraries: (libraries: unknown[]) => Promise<void>;
+        isServerSelected: () => Promise<boolean>;
+        getUserSelectedServer: () => Promise<PlexServer | null>;
+        getUserSelectedLibraries: () => Promise<unknown[] | null>;
+        getUserAccessToken: () => Promise<string>;
+        getUserProfile: () => Promise<UserProfile | null>;
+        closeLoopbackServer: () => Promise<void>;
+      };
       bass: {
-        getStatus: () => Promise<BassStatus>
-      }
+        getStatus: () => Promise<BassStatus>;
+      };
       media: {
         getHomeData: () => Promise<{
-          topEight: any[]
-          recentlyPlayed: any[]
-          recentlyAdded: any[]
-          playlists: any[]
-        }>
-        getTopEight: () => Promise<any[]>
-        getRecentlyPlayedAlbums: () => Promise<any[]>
-        getRecentlyAddedAlbums: () => Promise<any[]>
-        getPlaylists: () => Promise<any[]>
-        getAlbumsPage: (cursor: string, pageSize: number) => Promise<any>
-        getAlbum: (ratingKey: string) => Promise<any>
-        getArtist: (ratingKey: string) => Promise<any>
-        getArtistAlbums: (ratingKey: string) => Promise<any[]>
-        getArtistPopularTracks: (ratingKey: string) => Promise<any>
-        getPlaylist: (ratingKey: string) => Promise<any>
-      }
+          topEight: any[];
+          recentlyPlayed: any[];
+          recentlyAdded: any[];
+          playlists: any[];
+        }>;
+        getTopEight: () => Promise<any[]>;
+        getRecentlyPlayedAlbums: () => Promise<any[]>;
+        getRecentlyAddedAlbums: () => Promise<any[]>;
+        getPlaylists: () => Promise<any[]>;
+        getAlbumsPage: (cursor: string, pageSize: number) => Promise<any>;
+        getArtistsPage: (cursor: string, pageSize: number) => Promise<any>;
+        getAlbum: (ratingKey: string) => Promise<any>;
+        getArtist: (ratingKey: string) => Promise<any>;
+        getArtistAlbums: (ratingKey: string) => Promise<any[]>;
+        getArtistPopularTracks: (ratingKey: string) => Promise<any>;
+        getPlaylist: (ratingKey: string) => Promise<any>;
+      };
       player: {
-        getStatus: () => Promise<PlayerStatus>
-        playAlbum: (ratingKey: string) => Promise<unknown>
-        playPlaylist: (ratingKey: string) => Promise<unknown>
-        playArtist: (ratingKey: string) => Promise<unknown>
-        playTrack: (ratingKey: string) => Promise<unknown>
-        play: () => Promise<unknown>
-        pause: () => Promise<unknown>
-        next: () => Promise<unknown>
-        prev: () => Promise<unknown>
-        seek: (position: number) => Promise<unknown>
-        setVolume: (volume: number) => Promise<unknown>
-        setMuted: (muted: boolean) => Promise<unknown>
-      }
-    }
+        getStatus: () => Promise<PlayerStatus>;
+        playAlbum: (ratingKey: string) => Promise<unknown>;
+        playPlaylist: (ratingKey: string) => Promise<unknown>;
+        playArtist: (ratingKey: string) => Promise<unknown>;
+        playTrack: (ratingKey: string) => Promise<unknown>;
+        play: () => Promise<unknown>;
+        pause: () => Promise<unknown>;
+        next: () => Promise<unknown>;
+        prev: () => Promise<unknown>;
+        seek: (position: number) => Promise<unknown>;
+        setVolume: (volume: number) => Promise<unknown>;
+        setMuted: (muted: boolean) => Promise<unknown>;
+      };
+    };
   }
 }
 
-export {}
+export {};

--- a/src/renderer/src/routes/app/library/artists.tsx
+++ b/src/renderer/src/routes/app/library/artists.tsx
@@ -1,9 +1,136 @@
-import { createFileRoute } from "@tanstack/react-router";
+import BlankImage from "@/assets/512px-Black_colour.jpg";
+import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import React, { useEffect, useRef } from "react";
 
 export const Route = createFileRoute("/app/library/artists")({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  return <div>Hello "/app/(library)/artists"!</div>;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const observerRef = useRef<HTMLDivElement>(null);
+
+  const fetchArtists = async ({ pageParam }: { pageParam: string }) => {
+    return window.api.media.getArtistsPage(pageParam || "", 30);
+  };
+
+  const {
+    data,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isFetchingNextPage,
+    status,
+  } = useInfiniteQuery({
+    queryKey: ["allArtists"],
+    queryFn: fetchArtists,
+    initialPageParam: "",
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+  });
+
+  useEffect(() => {
+    if (!containerRef.current || !hasNextPage || isFetching) return;
+
+    const container = containerRef.current;
+    const hasScroll = container.scrollHeight > container.clientHeight;
+
+    if (!hasScroll) {
+      fetchNextPage();
+    }
+  }, [data, hasNextPage, isFetching, fetchNextPage]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && hasNextPage && !isFetching) {
+        fetchNextPage();
+      }
+    });
+
+    const target = observerRef.current;
+    if (target) {
+      observer.observe(target);
+    }
+
+    return () => {
+      if (target) observer.unobserve(target);
+    };
+  }, [hasNextPage, isFetching, fetchNextPage]);
+
+  if (status === "pending") {
+    return (
+      <div className="flex min-h-full items-center justify-center">
+        <Spinner className="size-8" />
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div className="flex min-h-full items-center justify-center px-6 text-sm text-muted-foreground">
+        Error loading artists: {error.message}
+      </div>
+    );
+  }
+
+  const artists = data.pages.flatMap((group) => group.items);
+
+  return (
+    <div ref={containerRef} className="flex min-h-full flex-col px-6">
+      <div className="sticky top-0 z-10 w-full bg-background py-2">
+        <p className="text-2xl font-bold">Artists</p>
+      </div>
+
+      {artists.length > 0 ? (
+        <div className="flex w-full flex-wrap">
+          {data.pages.map((group, i) => (
+            <React.Fragment key={i}>
+              {group.items.map((artist: any) => (
+                <ArtistCard key={artist.id} artist={artist} />
+              ))}
+            </React.Fragment>
+          ))}
+        </div>
+      ) : (
+        <div className="flex h-48 items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground">
+          No artists found
+        </div>
+      )}
+
+      <div ref={observerRef} className="flex h-12 items-center justify-center">
+        {isFetching && !isFetchingNextPage ? (
+          <Spinner className="size-4" />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ArtistCard({ artist }: { artist: any }) {
+  return (
+    <Link
+      to={`/app/artist/$ratingKey`}
+      params={{ ratingKey: String(artist.ratingKey) }}
+      className="h-fit"
+    >
+      <Card className="flex w-40 shrink-0 justify-center border-0 bg-transparent p-3 shadow-none ring-0 hover:rounded-lg hover:bg-zinc-300/60 dark:hover:bg-zinc-800/60">
+        <CardHeader className="gap-0 p-0">
+          <img
+            src={artist.thumb ?? BlankImage}
+            alt={artist.title}
+            className="mb-2 aspect-square w-full rounded-full object-cover"
+          />
+          <CardTitle className="mb-0.5 overflow-hidden text-ellipsis text-nowrap text-sm leading-tight">
+            <p className="truncate hover:underline">{artist.title}</p>
+          </CardTitle>
+          <p className="truncate text-xs leading-tight text-black/80 dark:text-muted-foreground">
+            Artist
+          </p>
+        </CardHeader>
+      </Card>
+    </Link>
+  );
 }

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -179,6 +179,10 @@ export type RaynaRPC = {
         params: { cursor?: string; pageSize: number };
         response: unknown;
       };
+      mediaGetArtistsPage: {
+        params: { cursor?: string; pageSize: number };
+        response: unknown;
+      };
       mediaGetAlbum: {
         params: { ratingKey: string };
         response: unknown;


### PR DESCRIPTION
## Summary
- Added a real artist library page at `/app/library/artists` with infinite scroll, loading/error states, and links into existing artist detail pages.
- Added a new `mediaGetArtistsPage` RPC path in the Bun backend and renderer bridge so artists are fetched from Plex instead of using a placeholder view.
- Exposed Artists in the sidebar and marked the roadmap item complete in the README.

## Testing
- `bun run route:generate` passed.
- `bun run typecheck:bun` passed.
- Targeted ESLint on the edited source files passed.
- Full web typecheck still reports pre-existing unrelated errors in other renderer files.