### PR TITLE
Add a playlists library page and wire it into the sidebar

### DIFF
--- a/src/renderer/src/components/app-sidebar.tsx
+++ b/src/renderer/src/components/app-sidebar.tsx
@@ -12,6 +12,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import {
   AudioWave01FreeIcons,
   Home02Icon,
+  LibraryIcon,
   MusicNote03Icon,
   Vynil03Icon,
 } from "@hugeicons/core-free-icons";
@@ -108,7 +109,7 @@ const data = {
     // },
     { name: "Albums", url: "/app/library/albums", icon: Vynil03Icon },
     { name: "Artists", url: "/app/library/artists", icon: MusicNote03Icon },
-    // { name: "Playlists", url: "/app/library/playlists", icon: DiscAlbum },
+    { name: "Playlists", url: "/app/library/playlists", icon: LibraryIcon },
     // {
     //   name: "All Music",
     //   url: "#",

--- a/src/renderer/src/routeTree.gen.ts
+++ b/src/renderer/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as AppSettingsRouteImport } from './routes/app/settings'
 import { Route as AppLibraryRouteRouteImport } from './routes/app/library/route'
 import { Route as AppPlaylistRatingKeyRouteImport } from './routes/app/playlist.$ratingKey'
 import { Route as AppLibraryTracksRouteImport } from './routes/app/library/tracks'
+import { Route as AppLibraryPlaylistsRouteImport } from './routes/app/library/playlists'
 import { Route as AppLibraryArtistsRouteImport } from './routes/app/library/artists'
 import { Route as AppLibraryAlbumsRouteImport } from './routes/app/library/albums'
 import { Route as AppArtistRatingKeyRouteImport } from './routes/app/artist.$ratingKey'
@@ -68,6 +69,11 @@ const AppLibraryTracksRoute = AppLibraryTracksRouteImport.update({
   path: '/tracks',
   getParentRoute: () => AppLibraryRouteRoute,
 } as any)
+const AppLibraryPlaylistsRoute = AppLibraryPlaylistsRouteImport.update({
+  id: '/playlists',
+  path: '/playlists',
+  getParentRoute: () => AppLibraryRouteRoute,
+} as any)
 const AppLibraryArtistsRoute = AppLibraryArtistsRouteImport.update({
   id: '/artists',
   path: '/artists',
@@ -101,6 +107,7 @@ export interface FileRoutesByFullPath {
   '/app/artist/$ratingKey': typeof AppArtistRatingKeyRoute
   '/app/library/albums': typeof AppLibraryAlbumsRoute
   '/app/library/artists': typeof AppLibraryArtistsRoute
+  '/app/library/playlists': typeof AppLibraryPlaylistsRoute
   '/app/library/tracks': typeof AppLibraryTracksRoute
   '/app/playlist/$ratingKey': typeof AppPlaylistRatingKeyRoute
 }
@@ -115,6 +122,7 @@ export interface FileRoutesByTo {
   '/app/artist/$ratingKey': typeof AppArtistRatingKeyRoute
   '/app/library/albums': typeof AppLibraryAlbumsRoute
   '/app/library/artists': typeof AppLibraryArtistsRoute
+  '/app/library/playlists': typeof AppLibraryPlaylistsRoute
   '/app/library/tracks': typeof AppLibraryTracksRoute
   '/app/playlist/$ratingKey': typeof AppPlaylistRatingKeyRoute
 }
@@ -131,6 +139,7 @@ export interface FileRoutesById {
   '/app/artist/$ratingKey': typeof AppArtistRatingKeyRoute
   '/app/library/albums': typeof AppLibraryAlbumsRoute
   '/app/library/artists': typeof AppLibraryArtistsRoute
+  '/app/library/playlists': typeof AppLibraryPlaylistsRoute
   '/app/library/tracks': typeof AppLibraryTracksRoute
   '/app/playlist/$ratingKey': typeof AppPlaylistRatingKeyRoute
 }
@@ -148,6 +157,7 @@ export interface FileRouteTypes {
     | '/app/artist/$ratingKey'
     | '/app/library/albums'
     | '/app/library/artists'
+    | '/app/library/playlists'
     | '/app/library/tracks'
     | '/app/playlist/$ratingKey'
   fileRoutesByTo: FileRoutesByTo
@@ -162,6 +172,7 @@ export interface FileRouteTypes {
     | '/app/artist/$ratingKey'
     | '/app/library/albums'
     | '/app/library/artists'
+    | '/app/library/playlists'
     | '/app/library/tracks'
     | '/app/playlist/$ratingKey'
   id:
@@ -177,6 +188,7 @@ export interface FileRouteTypes {
     | '/app/artist/$ratingKey'
     | '/app/library/albums'
     | '/app/library/artists'
+    | '/app/library/playlists'
     | '/app/library/tracks'
     | '/app/playlist/$ratingKey'
   fileRoutesById: FileRoutesById
@@ -253,6 +265,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppLibraryTracksRouteImport
       parentRoute: typeof AppLibraryRouteRoute
     }
+    '/app/library/playlists': {
+      id: '/app/library/playlists'
+      path: '/playlists'
+      fullPath: '/app/library/playlists'
+      preLoaderRoute: typeof AppLibraryPlaylistsRouteImport
+      parentRoute: typeof AppLibraryRouteRoute
+    }
     '/app/library/artists': {
       id: '/app/library/artists'
       path: '/artists'
@@ -287,12 +306,14 @@ declare module '@tanstack/react-router' {
 interface AppLibraryRouteRouteChildren {
   AppLibraryAlbumsRoute: typeof AppLibraryAlbumsRoute
   AppLibraryArtistsRoute: typeof AppLibraryArtistsRoute
+  AppLibraryPlaylistsRoute: typeof AppLibraryPlaylistsRoute
   AppLibraryTracksRoute: typeof AppLibraryTracksRoute
 }
 
 const AppLibraryRouteRouteChildren: AppLibraryRouteRouteChildren = {
   AppLibraryAlbumsRoute: AppLibraryAlbumsRoute,
   AppLibraryArtistsRoute: AppLibraryArtistsRoute,
+  AppLibraryPlaylistsRoute: AppLibraryPlaylistsRoute,
   AppLibraryTracksRoute: AppLibraryTracksRoute,
 }
 

--- a/src/renderer/src/routes/app/library/playlists.tsx
+++ b/src/renderer/src/routes/app/library/playlists.tsx
@@ -1,0 +1,140 @@
+import BlankImage from "@/assets/512px-Black_colour.jpg";
+import { Spinner } from "@/components/ui/spinner";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+dayjs.extend(duration);
+
+export const Route = createFileRoute("/app/library/playlists")({
+  component: RouteComponent,
+});
+
+const PLAYLIST_BATCH_SIZE = 80;
+
+function RouteComponent() {
+  const observerRef = useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = useState(PLAYLIST_BATCH_SIZE);
+
+  const queryPlaylists = useQuery({
+    queryKey: ["playlists"],
+    queryFn: () => window.api.media.getPlaylists(),
+    staleTime: 60_000,
+  });
+
+  const playlists = useMemo(
+    () => queryPlaylists.data ?? [],
+    [queryPlaylists.data],
+  );
+  const visiblePlaylists = useMemo(
+    () => playlists.slice(0, visibleCount),
+    [playlists, visibleCount],
+  );
+  const hasMore = visibleCount < playlists.length;
+
+  useEffect(() => {
+    setVisibleCount(PLAYLIST_BATCH_SIZE);
+  }, [playlists.length]);
+
+  useEffect(() => {
+    if (!observerRef.current || !hasMore) {
+      return;
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        setVisibleCount((count) =>
+          Math.min(count + PLAYLIST_BATCH_SIZE, playlists.length),
+        );
+      }
+    });
+
+    observer.observe(observerRef.current);
+
+    return () => observer.disconnect();
+  }, [hasMore, playlists.length]);
+
+  if (queryPlaylists.isLoading) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <Spinner className="size-8" />
+      </div>
+    );
+  }
+
+  if (queryPlaylists.isError) {
+    return (
+      <div className="flex min-h-full flex-col px-6 py-4">
+        <p className="text-2xl font-bold">Playlists</p>
+        <p className="mt-4 text-sm text-destructive">
+          Error: {queryPlaylists.error.message}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-full flex-col px-6 pb-8">
+      <div className="sticky top-0 z-10 w-full bg-background py-2">
+        <p className="text-2xl font-bold">Playlists</p>
+        <p className="text-sm text-muted-foreground">
+          {playlists.length} {playlists.length === 1 ? "playlist" : "playlists"}
+        </p>
+      </div>
+
+      {playlists.length === 0 ? (
+        <div className="mt-4 flex min-h-32 items-center rounded-md border border-dashed border-zinc-300 bg-zinc-50/60 px-6 text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900/30 dark:text-zinc-400">
+          <span className="text-sm">No playlists found</span>
+        </div>
+      ) : (
+        <>
+          <div className="flex w-full flex-wrap">
+            {visiblePlaylists.map((playlist) => (
+              <PlaylistCard key={playlist.id} playlist={playlist} />
+            ))}
+          </div>
+          <div ref={observerRef} className="flex h-12 items-center">
+            {hasMore ? <Spinner className="size-4" /> : null}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function PlaylistCard({ playlist }: { playlist: any }) {
+  const image = playlist.composite?.length > 0 ? playlist.composite : BlankImage;
+  const length = playlist.duration
+    ? `${dayjs.duration(playlist.duration).hours()}hr ${dayjs
+        .duration(playlist.duration)
+        .minutes()}min`
+    : "0hr 0min";
+
+  return (
+    <Link
+      to="/app/playlist/$ratingKey"
+      params={{ ratingKey: playlist.ratingKey }}
+      preload="intent"
+      className="h-fit"
+    >
+      <div className="flex w-40 shrink-0 justify-center rounded-md bg-transparent p-3 hover:bg-zinc-300/60 dark:hover:bg-zinc-800/60">
+        <div className="min-w-0">
+          <img
+            src={image}
+            alt={playlist.title}
+            className="mb-1.5 aspect-square w-full rounded-lg object-cover"
+            loading="lazy"
+          />
+          <p className="mb-0.5 truncate text-sm leading-tight hover:underline">
+            {playlist.title}
+          </p>
+          <p className="truncate text-xs leading-tight text-black/80 dark:text-muted-foreground">
+            {playlist.smart ? "Smart playlist" : "Playlist"} · {length}
+          </p>
+        </div>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- Added a dedicated `/app/library/playlists` view that reuses the existing `getPlaylists()` data source.
- Matched the albums/artists library presentation with compact square cards, lazy-loaded artwork, and a scroll-triggered batch loader for larger Plex libraries.
- Added Playlists to the sidebar so navigation into the existing playlist detail page is direct and consistent.
