### PR TITLE
Add Plex timeline session reporting with remote stop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ On install login to you Plex account and select your server[^1], that is all.
 - [x] Server select
   - [ ] Change selected server
   - [x] Select libraries
-- [ ] Sessions support
-- [ ] Timeline support
+- [x] Sessions support
+- [x] Timeline support
 - [ ] Transcoding
 - [ ] Sync
 - [ ] TV Support (Probably never happening)

--- a/src/bun/bass.ts
+++ b/src/bun/bass.ts
@@ -21,6 +21,39 @@ type PlayableTrack = {
   streamUrl: string;
 };
 
+export type BassStopReason = "manual" | "replaced" | "ended" | "remote";
+
+export type BassPlaybackEvent =
+  | {
+      type: "track-started";
+      track: PlayerTrack;
+      position: number;
+      duration: number;
+    }
+  | {
+      type: "state-changed";
+      state: "playing" | "paused";
+      track: PlayerTrack;
+      position: number;
+      duration: number;
+    }
+  | {
+      type: "seeked";
+      track: PlayerTrack;
+      position: number;
+      duration: number;
+      isPlaying: boolean;
+    }
+  | {
+      type: "track-stopped";
+      reason: BassStopReason;
+      track: PlayerTrack;
+      position: number;
+      duration: number;
+    };
+
+export type BassPlaybackListener = (event: BassPlaybackEvent) => void;
+
 type BassLibrary = {
   symbols: {
     BASS_GetVersion: () => number;
@@ -84,6 +117,7 @@ export class BassManager {
   private volumeBeforeMute = 1;
   private monitor: Timer | null = null;
   private manuallyStopping = false;
+  private listeners = new Set<BassPlaybackListener>();
   private readonly libraryPath: string | null;
 
   constructor() {
@@ -122,16 +156,21 @@ export class BassManager {
     };
   }
 
+  onPlaybackEvent(listener: BassPlaybackListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
   playTrack(track: PlayerTrack, streamUrl: string): void {
     this.rememberCurrentTrack();
-    this.stop();
+    this.stopCurrent("replaced");
     this.queue = [];
     this.playStream(track, streamUrl);
   }
 
   playTracks(tracks: PlayableTrack[]): void {
     this.rememberCurrentTrack();
-    this.stop();
+    this.stopCurrent("replaced");
     this.queue = tracks;
     this.playNext();
   }
@@ -167,26 +206,44 @@ export class BassManager {
 
   resume(): void {
     if (!this.library || !this.streamHandle) return;
-    this.library.symbols.BASS_ChannelPlay(this.streamHandle, false);
+    const resumed = this.library.symbols.BASS_ChannelPlay(
+      this.streamHandle,
+      false,
+    );
+    if (resumed && this.currentTrack) {
+      this.emitPlaybackEvent({
+        type: "state-changed",
+        state: "playing",
+        track: this.currentTrack,
+        position: this.getPosition(),
+        duration: this.getDuration(),
+      });
+    }
   }
 
   pause(): void {
     if (!this.library || !this.streamHandle) return;
-    this.library.symbols.BASS_ChannelPause(this.streamHandle);
+    const position = this.getPosition();
+    const duration = this.getDuration();
+    const paused = this.library.symbols.BASS_ChannelPause(this.streamHandle);
+    if (paused && this.currentTrack) {
+      this.emitPlaybackEvent({
+        type: "state-changed",
+        state: "paused",
+        track: this.currentTrack,
+        position,
+        duration,
+      });
+    }
   }
 
   stop(): void {
-    if (!this.library) return;
-    this.manuallyStopping = true;
-    this.stopMonitor();
-    if (this.streamHandle) {
-      this.library.symbols.BASS_ChannelStop(this.streamHandle);
-      this.library.symbols.BASS_StreamFree(this.streamHandle);
-    }
-    this.streamHandle = 0;
-    this.currentPlayable = null;
-    this.currentTrack = null;
-    this.manuallyStopping = false;
+    this.stopCurrent("manual");
+  }
+
+  stopFromRemote(): void {
+    this.queue = [];
+    this.stopCurrent("remote");
   }
 
   playNext(): void {
@@ -235,6 +292,17 @@ export class BassManager {
 
     if (!seeked) {
       this.loadError = `BASS_ChannelSetPosition failed with error ${this.library.symbols.BASS_ErrorGetCode()}`;
+      return;
+    }
+
+    if (this.currentTrack) {
+      this.emitPlaybackEvent({
+        type: "seeked",
+        track: this.currentTrack,
+        position: safePosition,
+        duration: this.getDuration(),
+        isPlaying: this.isPlaying(),
+      });
     }
   }
 
@@ -427,13 +495,7 @@ export class BassManager {
     if (rememberCurrent) {
       this.rememberCurrentTrack();
     }
-    this.manuallyStopping = true;
-    this.stopMonitor();
-    if (this.streamHandle) {
-      this.library.symbols.BASS_ChannelStop(this.streamHandle);
-      this.library.symbols.BASS_StreamFree(this.streamHandle);
-    }
-    this.manuallyStopping = false;
+    this.stopCurrent("replaced");
 
     this.streamHandle = this.library.symbols.BASS_StreamCreateURL(
       this.toCString(streamUrl),
@@ -468,6 +530,12 @@ export class BassManager {
     }
 
     this.startMonitor();
+    this.emitPlaybackEvent({
+      type: "track-started",
+      track,
+      position: this.getPosition(),
+      duration: this.getDuration(),
+    });
   }
 
   private startMonitor(): void {
@@ -499,9 +567,49 @@ export class BassManager {
       duration <= 0 || position >= Math.max(0, duration - 0.75);
 
     if (reachedEnd) {
-      this.stopMonitor();
+      this.stopCurrent("ended");
       this.playNext();
     }
+  }
+
+  private stopCurrent(reason: BassStopReason): void {
+    if (!this.library) return;
+
+    const stoppedTrack = this.currentTrack;
+    const stoppedPosition = stoppedTrack ? this.getPosition() : 0;
+    const stoppedDuration = stoppedTrack ? this.getDuration() : 0;
+
+    this.manuallyStopping = true;
+    this.stopMonitor();
+    if (this.streamHandle) {
+      this.library.symbols.BASS_ChannelStop(this.streamHandle);
+      this.library.symbols.BASS_StreamFree(this.streamHandle);
+    }
+    this.streamHandle = 0;
+    this.currentPlayable = null;
+    this.currentTrack = null;
+    this.manuallyStopping = false;
+
+    if (stoppedTrack) {
+      this.emitPlaybackEvent({
+        type: "track-stopped",
+        reason,
+        track: stoppedTrack,
+        position: stoppedPosition,
+        duration: stoppedDuration,
+      });
+    }
+  }
+
+  private emitPlaybackEvent(event: BassPlaybackEvent): void {
+    this.listeners.forEach((listener) => {
+      try {
+        listener(event);
+      } catch (error) {
+        this.loadError =
+          error instanceof Error ? error.message : String(error);
+      }
+    });
   }
 
   private isPlaying(): boolean {

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -3,6 +3,7 @@ import { BassManager } from "./bass";
 import { DatabaseManager } from "./database";
 import Authentication from "./plex/authentication";
 import { MediaService } from "./plex/media";
+import { PlexTimelineReporter } from "./plex/timeline";
 import type { ApplicationMenuItemConfig } from "electrobun";
 import type { RaynaRPC } from "../shared/rpc";
 import type { PlexServer } from "../shared/types";
@@ -11,6 +12,10 @@ const db = new DatabaseManager();
 const auth = new Authentication();
 const bass = new BassManager();
 const media = new MediaService(auth, bass, db);
+const timeline = new PlexTimelineReporter(auth, bass, () =>
+  media.getPlaybackSettings(),
+);
+timeline.start();
 
 const isMac = process.platform === "darwin";
 
@@ -211,5 +216,6 @@ function extractUrl(event: unknown): string | null {
 
 function shutdown(): void {
   bass.free();
+  timeline.dispose();
   Utils.quit();
 }

--- a/src/bun/plex/media.ts
+++ b/src/bun/plex/media.ts
@@ -44,17 +44,21 @@ export class MediaService {
   ) {}
 
   getPlaybackSettings(): PlaybackSettings {
-    return (
-      (this.db.get("playback") as PlaybackSettings | null) ?? {
-        useOriginalFileUrl: true,
-        enableUltraBlur: true,
-      }
-    );
+    return {
+      useOriginalFileUrl: true,
+      enableUltraBlur: true,
+      enableTimelineReporting: true,
+      ...((this.db.get("playback") as PlaybackSettings | null) ?? {}),
+    };
   }
 
   setPlaybackSettings(settings: PlaybackSettings): PlaybackSettings {
-    this.db.set("playback", settings);
-    return settings;
+    const next = {
+      ...this.getPlaybackSettings(),
+      ...settings,
+    };
+    this.db.set("playback", next);
+    return next;
   }
 
   async getAlbumsPage(cursor = "", pageSize = 20): Promise<unknown> {

--- a/src/bun/plex/timeline.ts
+++ b/src/bun/plex/timeline.ts
@@ -1,0 +1,454 @@
+import { hostname, platform, release } from "node:os";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+import type {
+  BassManager,
+  BassPlaybackEvent,
+  BassStopReason,
+} from "../bass";
+import type Authentication from "./authentication";
+import type { PlaybackSettings, PlayerTrack } from "../../shared/rpc";
+import type { PlexServer } from "../../shared/types";
+
+type TimelineState = "playing" | "paused" | "stopped";
+
+type ActiveTimelineSession = {
+  sessionId: string;
+  track: PlayerTrack;
+  state: TimelineState;
+  pausedTicks: number;
+};
+
+type TimelineResponse = {
+  MediaContainer?: {
+    terminationCode?: unknown;
+    terminationText?: unknown;
+  };
+  rawText?: string;
+  terminationCode?: unknown;
+  terminationText?: unknown;
+};
+
+const PLEX_TIMELINE_TIMEOUT_MS = 8_000;
+const PLAYING_HEARTBEAT_MS = 10_000;
+const PAUSED_HEARTBEAT_TICKS = 6;
+const RAYNA_VERSION = readPackageVersion();
+
+export class PlexTimelineReporter {
+  private activeBaseUrl: string | null = null;
+  private activeSession: ActiveTimelineSession | null = null;
+  private heartbeat: Timer | null = null;
+  private unsubscribe: (() => void) | null = null;
+  private handlingTermination = false;
+
+  constructor(
+    private readonly auth: Authentication,
+    private readonly bass: BassManager,
+    private readonly getPlaybackSettings: () => PlaybackSettings,
+  ) {}
+
+  start(): void {
+    if (this.unsubscribe) return;
+    this.unsubscribe = this.bass.onPlaybackEvent((event) =>
+      this.handlePlaybackEvent(event),
+    );
+  }
+
+  dispose(): void {
+    this.stopHeartbeat();
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.activeSession = null;
+  }
+
+  private handlePlaybackEvent(event: BassPlaybackEvent): void {
+    if (!this.isEnabled()) {
+      this.stopHeartbeat();
+      this.activeSession = null;
+      return;
+    }
+
+    if (this.handlingTermination) {
+      if (event.type === "track-stopped" && event.reason === "remote") {
+        this.stopHeartbeat();
+        this.activeSession = null;
+      }
+      return;
+    }
+
+    if (event.type === "track-started") {
+      this.startSession(event.track, event.position, event.duration);
+      return;
+    }
+
+    if (event.type === "state-changed") {
+      this.reportSessionState(
+        event.track,
+        event.state,
+        event.position,
+        event.duration,
+      );
+      return;
+    }
+
+    if (event.type === "seeked") {
+      this.reportSessionState(
+        event.track,
+        event.isPlaying ? "playing" : "paused",
+        event.position,
+        event.duration,
+      );
+      return;
+    }
+
+    this.stopSession(event.reason, event.track, event.position, event.duration);
+  }
+
+  private startSession(
+    track: PlayerTrack,
+    position: number,
+    duration: number,
+  ): void {
+    this.stopHeartbeat();
+    this.activeSession = {
+      sessionId: this.generateSessionId(),
+      track,
+      state: "playing",
+      pausedTicks: 0,
+    };
+    void this.report("playing", track, position, duration);
+    this.startHeartbeat();
+  }
+
+  private reportSessionState(
+    track: PlayerTrack,
+    state: "playing" | "paused",
+    position: number,
+    duration: number,
+  ): void {
+    const session = this.ensureSession(track);
+    session.state = state;
+    session.pausedTicks = 0;
+    void this.report(state, track, position, duration);
+    this.startHeartbeat();
+  }
+
+  private stopSession(
+    reason: BassStopReason,
+    track: PlayerTrack,
+    position: number,
+    duration: number,
+  ): void {
+    const session = this.activeSession;
+    if (!session || session.track.ratingKey !== track.ratingKey) return;
+
+    this.stopHeartbeat();
+    this.activeSession = null;
+
+    if (reason === "remote") return;
+    void this.report("stopped", track, position, duration, session.sessionId);
+  }
+
+  private ensureSession(track: PlayerTrack): ActiveTimelineSession {
+    if (this.activeSession?.track.ratingKey === track.ratingKey) {
+      return this.activeSession;
+    }
+
+    this.activeSession = {
+      sessionId: this.generateSessionId(),
+      track,
+      state: "playing",
+      pausedTicks: 0,
+    };
+    return this.activeSession;
+  }
+
+  private startHeartbeat(): void {
+    if (this.heartbeat) return;
+    this.heartbeat = setInterval(() => {
+      const session = this.activeSession;
+      if (!session || !this.isEnabled()) {
+        this.stopHeartbeat();
+        this.activeSession = null;
+        return;
+      }
+
+      if (session.state === "paused") {
+        session.pausedTicks += 1;
+        if (session.pausedTicks < PAUSED_HEARTBEAT_TICKS) return;
+        session.pausedTicks = 0;
+      }
+
+      const status = this.bass.getPlaybackStatus();
+      void this.report(
+        session.state,
+        session.track,
+        status.position,
+        status.duration,
+      );
+    }, PLAYING_HEARTBEAT_MS);
+  }
+
+  private stopHeartbeat(): void {
+    if (!this.heartbeat) return;
+    clearInterval(this.heartbeat);
+    this.heartbeat = null;
+  }
+
+  private async report(
+    state: TimelineState,
+    track: PlayerTrack,
+    positionSeconds: number,
+    durationSeconds: number,
+    sessionIdOverride?: string,
+  ): Promise<void> {
+    if (!this.isEnabled()) return;
+
+    const sessionId = sessionIdOverride || this.activeSession?.sessionId;
+    if (!sessionId || !track.ratingKey) return;
+
+    try {
+      const response = await this.fetchTimeline(
+        track,
+        state,
+        positionSeconds,
+        durationSeconds || secondsFromMilliseconds(track.duration),
+        sessionId,
+      );
+
+      if (this.isTerminationResponse(response)) {
+        this.handleRemoteTermination();
+      }
+    } catch {
+      // Timeline reporting must not interrupt local playback.
+    }
+  }
+
+  private async fetchTimeline(
+    track: PlayerTrack,
+    state: TimelineState,
+    positionSeconds: number,
+    durationSeconds: number,
+    sessionId: string,
+  ): Promise<TimelineResponse | null> {
+    const server = await this.getSelectedServer();
+    const token = this.getServerToken(server);
+    const connections = this.orderConnections(server);
+    let lastError: unknown = null;
+
+    for (const connection of connections) {
+      try {
+        const url = new URL("/:/timeline", connection.uri);
+        const params = this.timelineParams(
+          track,
+          state,
+          positionSeconds,
+          durationSeconds,
+        );
+
+        Object.entries(params).forEach(([key, value]) => {
+          url.searchParams.set(key, value);
+        });
+        Object.entries(this.identityParams(sessionId)).forEach(
+          ([key, value]) => {
+            url.searchParams.set(key, value);
+          },
+        );
+        url.searchParams.set("X-Plex-Token", token);
+
+        const response = await fetch(url, {
+          method: "GET",
+          signal: AbortSignal.timeout(PLEX_TIMELINE_TIMEOUT_MS),
+          headers: this.playbackHeaders(token, sessionId),
+        });
+
+        if (!response.ok) {
+          lastError = new Error(
+            `Plex timeline failed at ${connection.uri}: ${response.status}`,
+          );
+          continue;
+        }
+
+        this.activeBaseUrl = connection.uri;
+        return await this.parseResponse(response);
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    throw new Error(
+      `Plex timeline failed${lastError instanceof Error ? `: ${lastError.message}` : ""}`,
+    );
+  }
+
+  private timelineParams(
+    track: PlayerTrack,
+    state: TimelineState,
+    positionSeconds: number,
+    durationSeconds: number,
+  ): Record<string, string> {
+    const ratingKey = track.ratingKey;
+    const time = String(secondsToMilliseconds(positionSeconds));
+    const duration = String(secondsToMilliseconds(durationSeconds));
+
+    return {
+      type: "music",
+      key: `/library/metadata/${ratingKey}`,
+      ratingKey,
+      state,
+      time,
+      playbackTime: time,
+      duration,
+      context: "source:content.library",
+      hasMDE: "1",
+    };
+  }
+
+  private playbackHeaders(
+    token: string,
+    sessionId: string,
+  ): Record<string, string> {
+    const identity = this.identityParams(sessionId);
+
+    return {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "X-Plex-Token": token,
+      ...identity,
+    };
+  }
+
+  private identityParams(sessionId: string): Record<string, string> {
+    return {
+      "X-Plex-Client-Identifier": this.auth.plexClientId,
+      "X-Plex-Session-Identifier": sessionId,
+      "X-Plex-Product": this.auth.plexProduct,
+      "X-Plex-Version": RAYNA_VERSION,
+      "X-Plex-Platform": platformName(),
+      "X-Plex-Platform-Version": release(),
+      "X-Plex-Device-Name": deviceName(),
+    };
+  }
+
+  private async parseResponse(
+    response: Response,
+  ): Promise<TimelineResponse | null> {
+    const text = await response.text();
+    if (!text.trim()) return null;
+
+    try {
+      return JSON.parse(text) as TimelineResponse;
+    } catch {
+      return { rawText: text };
+    }
+  }
+
+  private isTerminationResponse(response: TimelineResponse | null): boolean {
+    const container = response?.MediaContainer || response || null;
+    if (!container) return false;
+
+    if (
+      typeof response?.rawText === "string" &&
+      /\btermination(Code|Text)\b/i.test(response.rawText)
+    ) {
+      return true;
+    }
+
+    return (
+      container.terminationCode !== undefined ||
+      container.terminationText !== undefined
+    );
+  }
+
+  private handleRemoteTermination(): void {
+    if (this.handlingTermination) return;
+
+    this.handlingTermination = true;
+    this.stopHeartbeat();
+    this.activeSession = null;
+    this.bass.stopFromRemote();
+    this.handlingTermination = false;
+  }
+
+  private orderConnections(server: PlexServer): PlexServer["connections"] {
+    const connections = server.connections.filter(
+      (connection) => connection.uri,
+    );
+
+    return [
+      ...connections.filter(
+        (connection) => connection.uri === this.activeBaseUrl,
+      ),
+      ...connections.filter(
+        (connection) =>
+          connection.uri !== this.activeBaseUrl &&
+          connection.local &&
+          !connection.relay,
+      ),
+      ...connections.filter(
+        (connection) =>
+          connection.uri !== this.activeBaseUrl &&
+          !connection.local &&
+          !connection.relay,
+      ),
+      ...connections.filter(
+        (connection) =>
+          connection.uri !== this.activeBaseUrl && connection.relay,
+      ),
+    ];
+  }
+
+  private async getSelectedServer(): Promise<PlexServer> {
+    const server = await this.auth.getUserSelectedServer();
+    if (!server?.connections?.[0]?.uri) {
+      throw new Error("No Plex server is selected");
+    }
+    return server;
+  }
+
+  private getServerToken(server: PlexServer): string {
+    return server.accessToken || this.auth.plexUserAccessToken;
+  }
+
+  private isEnabled(): boolean {
+    return this.getPlaybackSettings().enableTimelineReporting !== false;
+  }
+
+  private generateSessionId(): string {
+    return randomUUID().replaceAll("-", "");
+  }
+}
+
+function secondsToMilliseconds(seconds: number): number {
+  if (!Number.isFinite(seconds) || seconds <= 0) return 0;
+  return Math.max(0, Math.floor(seconds * 1000));
+}
+
+function secondsFromMilliseconds(milliseconds: number | undefined): number {
+  if (!milliseconds || !Number.isFinite(milliseconds)) return 0;
+  return milliseconds / 1000;
+}
+
+function platformName(): string {
+  if (process.platform === "darwin") return "macOS";
+  if (process.platform === "win32") return "Windows";
+  if (process.platform === "linux") return "Linux";
+  return process.platform;
+}
+
+function deviceName(): string {
+  const name = hostname();
+  return name ? `Rayna on ${name}` : "Rayna";
+}
+
+function readPackageVersion(): string {
+  try {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(process.cwd(), "package.json"), "utf8"),
+    ) as { version?: unknown };
+    return typeof packageJson.version === "string" ? packageJson.version : "0";
+  } catch {
+    return "0";
+  }
+}

--- a/src/bun/plex/timeline.ts
+++ b/src/bun/plex/timeline.ts
@@ -218,7 +218,7 @@ export class PlexTimelineReporter {
       );
 
       if (this.isTerminationResponse(response)) {
-        this.handleRemoteTermination();
+        await this.handleRemoteTermination(track, sessionId);
       }
     } catch {
       // Timeline reporting must not interrupt local playback.
@@ -361,13 +361,28 @@ export class PlexTimelineReporter {
     );
   }
 
-  private handleRemoteTermination(): void {
+  private async handleRemoteTermination(
+    track: PlayerTrack,
+    sessionId: string,
+  ): Promise<void> {
     if (this.handlingTermination) return;
 
     this.handlingTermination = true;
     this.stopHeartbeat();
-    this.activeSession = null;
+    const status = this.bass.getPlaybackStatus();
     this.bass.stopFromRemote();
+    try {
+      await this.fetchTimeline(
+        track,
+        "stopped",
+        status.position,
+        status.duration || secondsFromMilliseconds(track.duration),
+        sessionId,
+      );
+    } catch {
+      // The server may already have terminated the session; local stop still wins.
+    }
+    this.activeSession = null;
     this.handlingTermination = false;
   }
 

--- a/src/renderer/src/routes/app/settings.tsx
+++ b/src/renderer/src/routes/app/settings.tsx
@@ -30,6 +30,8 @@ export function SettingsPage() {
   const [selectedServer, setSelectedServer] = useState<PlexServer | null>(null);
   const [playbackSettings, setPlaybackSettings] = useState<PlaybackSettings>({
     useOriginalFileUrl: true,
+    enableUltraBlur: true,
+    enableTimelineReporting: true,
   });
   const [loading, setLoading] = useState(true);
   const [updated, setUpdated] = useState(false);
@@ -85,6 +87,19 @@ export function SettingsPage() {
     const next = { ...playbackSettings, enableUltraBlur };
     setPlaybackSettings(next);
     setEnabled(enableUltraBlur);
+    await window.api.settings.setPlayback(next).catch((e) => console.error(e));
+    setPlaybackUpdated(true);
+
+    setTimeout(() => {
+      setPlaybackUpdated(false);
+    }, 1500);
+  };
+
+  const setEnableTimelineReporting = async (
+    enableTimelineReporting: boolean,
+  ) => {
+    const next = { ...playbackSettings, enableTimelineReporting };
+    setPlaybackSettings(next);
     await window.api.settings.setPlayback(next).catch((e) => console.error(e));
     setPlaybackUpdated(true);
 
@@ -212,6 +227,26 @@ export function SettingsPage() {
                     checked={playbackSettings.enableUltraBlur !== false}
                     onCheckedChange={setEnableUltraBlur}
                     aria-label="UltraBlur Background"
+                  />
+                </div>
+              </div>
+              <div className="flex items-center justify-between gap-6">
+                <div>
+                  <Label className="mb-2 block">Report playback to Plex</Label>
+                  <Label className="mb-2 block text-sm text-muted-foreground">
+                    Show Rayna in Plex and Tautulli active sessions.
+                  </Label>
+                </div>
+                <div className="flex items-center gap-4">
+                  {playbackUpdated && (
+                    <p className="text-green-700 dark:text-green-300">
+                      Updated
+                    </p>
+                  )}
+                  <Switch
+                    checked={playbackSettings.enableTimelineReporting !== false}
+                    onCheckedChange={setEnableTimelineReporting}
+                    aria-label="Report playback to Plex"
                   />
                 </div>
               </div>

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -56,6 +56,7 @@ export type PlayerStatus = {
 export type PlaybackSettings = {
   useOriginalFileUrl: boolean;
   enableUltraBlur?: boolean;
+  enableTimelineReporting?: boolean;
 };
 
 export type UserProfile = {


### PR DESCRIPTION
## Summary
- Add Bun-side Plex timeline reporting so Rayna shows up as an active Plex/Tautulli session and can be stopped remotely from Plex Dashboard or Tautulli.
- Introduce a dedicated timeline reporter that sends `/:/timeline` play, pause, seek, heartbeat, and stopped updates with stable Plex session identity.
- Wire playback lifecycle events through `BassManager` so local playback, queue transitions, and remote termination stay in sync.
- Add a playback setting to disable timeline reporting and expose it in the Settings UI.
- Update README documentation to reflect the new playback/session behavior.